### PR TITLE
Enable running tests via grunt command line

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -3,16 +3,29 @@ module.exports = function(grunt) {
 	grunt.initConfig({
 		pkg: grunt.file.readJSON('package.json'),
 		qunit: {
-			src: [
-				'tests/index.htm?module=Core',
-				'tests/index.htm?module=localstorage'
-				]
-		}
+			all: {
+        options: {
+          urls: [
+            'http://localhost:9001/tests/index.htm?module=Core',
+            'http://localhost:9001/tests/index.htm?module=localstorage'
+          ]
+        }
+      }
+		},
+    connect: {
+      server: {
+        options: {
+          port: 9001,
+          base: '.'
+        }
+      }
+    },
 	});
-
+  grunt.loadNpmTasks('grunt-contrib-connect');
 	grunt.loadNpmTasks('grunt-contrib-qunit');
-	grunt.registerTask('test', 'qunit:src');
 
-	// Default task(s).
+  grunt.registerTask('test', ['connect', 'qunit']);
+
+  // Default task(s).
 	grunt.registerTask('default', ['test']);
 };

--- a/package.json
+++ b/package.json
@@ -1,11 +1,17 @@
 {
   "name": "jStorage",
   "version": "0.0.1",
-  "devDependencies": {
-    "grunt": "~0.4.4",
-    "grunt-contrib-qunit": "~0.4.0"
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/flowertwig-org/jStorage.git"
   },
   "scripts": {
     "test": "grunt test"
+  },
+  "devDependencies": {
+    "grunt": "^1.0.1",
+    "grunt-contrib-connect": "^1.0.2",
+    "grunt-contrib-qunit": "^1.2.0"
   }
 }


### PR DESCRIPTION
This will make the tests pass again.

- Updated grunt and grunt-contrib-qunit to modern versions.
- Serve qunit over grunt connect server to enable parameters in the urls visited by phantomJS.
- Prepared for npm launch (#5)